### PR TITLE
Fix a flaky test.

### DIFF
--- a/fissa/tests/test_core.py
+++ b/fissa/tests/test_core.py
@@ -484,6 +484,10 @@ class ExperimentTestMixin:
         self.compare_str_repr_contents(repr(exp))
 
     def test_imagelistloaded_roizip(self):
+        image_path = os.path.join(self.resources_dir, self.images_dir)
+        roi_path = os.path.join(self.resources_dir, self.roi_zip_path)
+        exp = core.Experiment(image_path, roi_path, self.output_dir, datahandler_custom=datahandler)
+        exp.separate()
         image_paths = [os.path.join(self.images_dir, img) for img in self.image_names]
         datahandler = extraction.DataHandlerTifffile()
         images = [datahandler.image2array(pth) for pth in image_paths]


### PR DESCRIPTION
# What is the purpose of the change
- This PR is to fix a flaky test `fissa/tests/test_core.py::TestExperimentA::test_imagelistloaded_roizip`, after running `fissa/tests/test_core.py::TestExperimentA::test_lowmemorymode`.

# Reproduce the test failure
- Run the following command:
```
python -m pytest fissa/tests/test_core.py::TestExperimentA::test_lowmemorymode fissa/tests/test_core.py::TestExperimentA::test_imagelistloaded_roizip
```
# Actual result
```
E           AttributeError: 'numpy.ndarray' object has no attribute 'read'

/usr/lib/python3.8/multiprocessing/pool.py:771: AttributeError
```